### PR TITLE
Убран this(), обращения к методам объекта напрямую

### DIFF
--- a/src/stack.os
+++ b/src/stack.os
@@ -37,7 +37,7 @@ Function pop() Export
 
 	// we want to check for underflow and throw exception here
 	// peek() does this so we utilize it to reuse code
-	topValue = this().peek();
+	topValue = peek();
 	_StackContainer.delete( _StackContainer.UBound() );
 
 	return topValue;
@@ -53,7 +53,7 @@ EndFunction
 //
 Function peek() Export
 
-	If this().empty() Then
+	If empty() Then
 		Raise "stack underflow: attempt to get element out of empty stack object";
 	Endif;
 
@@ -69,7 +69,7 @@ EndFunction
 //
 Function empty() Export
 
-	Return 0 = this().count();
+	Return 0 = count();
 
 EndFunction
 
@@ -96,15 +96,6 @@ Procedure clear() Export
 	_StackContainer.Clear();
 
 EndProcedure
-
-
-Function this()
-
-	// early versions of intepreter didn't have ThisObject variable,
-	// only it's russian synonym - ЭтотОбъект
-	return ЭтотОбъект;
-
-EndFunction
 
 
 Procedure init()


### PR DESCRIPTION
## Summary
- Удалена функция `this()` — она была обходным путём для `ЭтотОбъект` в старых версиях интерпретатора; в текущем движке `ЭтотОбъект`/`ThisObject` доступен нативно как встроенное свойство скриптового объекта
- Вызовы `this().peek()`, `this().empty()`, `this().count()` заменены на прямые `peek()`, `empty()`, `count()` — вызов метода без префикса и так резолвится на сам объект

## Test plan
- [x] Полный набор тестов (29/29) прогнан на реальном движке OneScript — все зелёные, поведение не изменилось

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaAyAiQygBFTbJVY1NZTvN)_