### PR TITLE
Добавлена лицензия MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 leemuar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -98,3 +98,7 @@ opm install asserts
 opm install 1testrunner
 1testrunner -runall tests
 ```
+
+## Лицензия
+
+[MIT](LICENSE)


### PR DESCRIPTION
## Что сделано

- Добавлен файл `LICENSE` — MIT, правообладатель `leemuar`
- В README добавлен раздел «Лицензия» со ссылкой на файл

## Почему MIT

Пермиссивная лицензия без копилефт-ограничений: библиотеку можно свободно подключать в любые проекты, включая закрытые коммерческие конфигурации 1С — это основная аудитория OneScript-библиотек. Требует только сохранения текста копирайта.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CaAyAiQygBFTbJVY1NZTvN)_